### PR TITLE
Fix for "Bad arg length for Socket::unpack_sockaddr_in, length is 28,…

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+2016-01-20 AnyEvent::DNS::Nameserver v1.2
+Fix for "Bad arg length for Socket::unpack_sockaddr_in, length is 28, should be 16" when accepting IPv6 requests.
+
 2015-03-17 AnyEvent::DNS::Nameserver v1.1
 1)修复文档错误
 


### PR DESCRIPTION
Currently module fails on IPv6 requests. This patch enables IPv6 support.

To reproduce:
- Set an IPv6 address as LocalAddr when creating AnyEvent::DNS::Nameserver object
- Use "nslookup some_query IPv6_you_are_listening_at"
